### PR TITLE
Add Python requirements.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,7 @@ dmypy.json
 
 # txt
 *.txt
+!requirements.txt
 
 *.pth
 *.pt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+argdantic==1.3.3
+colorama==0.4.6
+exceptiongroup==1.3.1
+huggingface-hub==1.16.1
+hydra-core==1.3.2
+matplotlib==3.10.9
+numpy==2.2.6
+omegaconf==2.3.0
+pydantic==2.13.4
+pyyaml==6.0.3
+torch==2.12.0
+tqdm==4.67.3
+wandb==0.27.0


### PR DESCRIPTION
Adds the `requirements.txt` file referenced in the README, which is currently missing from the repository.

Tested:
- Created a fresh uv environment with `uv venv`.
- Installed dependencies with `uv pip install -r requirements.txt`.
- Verified core project imports and compiled Python sources.
- Downloaded artifacts with `bash scripts/download_artifacts.sh --with-ckpts`.
- Ran a two-step Sudoku training smoke test:
```bash
NPROC_PER_NODE=1 bash scripts/train.sh eqr_sudoku +max_steps=2 +wandb_mode=disabled eval_interval_steps=null checkpoint_interval_steps=null heavy_metrics_log_interval=null steps_hist_log_interval_steps=null grad_norm_log_interval_steps=null
```


Not exactly related to the pr:
1. adam-atan2==0.0.3 has broken PyPI metadata and lacks sm_120 support by default
2. Sudoku downloaded checkpoint eval currently has a checkpoint/config mismatch unrelated to the requirements file.